### PR TITLE
chore: add workflow to add VC Slot issues to project backlog

### DIFF
--- a/.github/workflows/add-vcslot-issues-to-project.yml
+++ b/.github/workflows/add-vcslot-issues-to-project.yml
@@ -1,0 +1,131 @@
+name: Add VC Slot issues to Project Backlog
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_numbers_csv:
+        description: "Comma-separated list of issue numbers to add"
+        required: true
+        default: "12,13,14,15,16,17,18,19,20,21"
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add specified issues to project and set Status to Backlog
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const projectUrl = 'https://github.com/users/irvingzamora28/projects/5';
+
+            // Parse inputs
+            const issueNumbers = core.getInput('issue_numbers_csv')
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean);
+
+            // Helper: GraphQL request
+            async function gql(query, variables){
+              return await github.graphql(query, variables);
+            }
+
+            // Get user project and Status field info
+            const userLogin = 'irvingzamora28';
+            const projectNumber = 5;
+
+            const projectData = await gql(`
+              query($login: String!, $number: Int!) {
+                user(login: $login) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 50) {
+                      nodes {
+                        ... on ProjectV2FieldCommon {
+                          id
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { login: userLogin, number: projectNumber });
+
+            const project = projectData.user.projectV2;
+            if(!project){
+              core.setFailed('Project not found.');
+              return;
+            }
+
+            const statusField = project.fields.nodes.find(f => f.name === 'Status');
+            if(!statusField){
+              core.setFailed('Status field not found on project.');
+              return;
+            }
+
+            const backlogOption = (statusField.options || []).find(o => o.name.toLowerCase() === 'backlog');
+            if(!backlogOption){
+              core.setFailed('Backlog option not found on Status field.');
+              return;
+            }
+
+            // Resolve repo id and issue node ids
+            const { repository } = await gql(`
+              query($owner:String!, $name:String!){
+                repository(owner:$owner, name:$name){ id }
+              }
+            `, { owner: context.repo.owner, name: context.repo.repo });
+
+            for (const number of issueNumbers) {
+              core.info(`Processing issue #${number}`);
+              const { repository: repoIssueData } = await gql(`
+                query($owner:String!, $name:String!, $number:Int!){
+                  repository(owner:$owner, name:$name){
+                    issue(number:$number){ id title }
+                  }
+                }
+              `, { owner: context.repo.owner, name: context.repo.repo, number: parseInt(number, 10) });
+
+              const issue = repoIssueData.issue;
+              if(!issue){
+                core.warning(`Issue #${number} not found, skipping`);
+                continue;
+              }
+
+              // Add to project
+              const addResp = await gql(`
+                mutation($projectId:ID!, $contentId:ID!){
+                  addProjectV2ItemById(input:{ projectId:$projectId, contentId:$contentId }){
+                    item { id }
+                  }
+                }
+              `, { projectId: project.id, contentId: issue.id });
+
+              const itemId = addResp.addProjectV2ItemById.item.id;
+              core.info(`Added issue #${number} to project as item ${itemId}`);
+
+              // Set Status = Backlog
+              await gql(`
+                mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }){ clientMutationId }
+                }
+              `, {
+                projectId: project.id,
+                itemId,
+                fieldId: statusField.id,
+                optionId: backlogOption.id
+              });
+
+              core.info(`Set Status to Backlog for issue #${number}`);
+            }


### PR DESCRIPTION
This PR adds a reusable workflow to add a list of issues to the "Lengofy Project" (user project v2 #5) and set their Status to "Backlog" via GitHub GraphQL.

Workflow: `.github/workflows/add-vcslot-issues-to-project.yml`
- Trigger: `workflow_dispatch`
- Input: `issue_numbers_csv` (default: 12,13,14,15,16,17,18,19,20,21)
- Logic:
  - Resolves the project (user: `irvingzamora28`, project number: 5)
  - Adds each issue to the project
  - Sets the `Status` single-select field to "Backlog"

After merge:
1) Go to Actions → "Add VC Slot issues to Project Backlog"
2) Click "Run workflow"
3) Leave the default issue list or adjust as needed
4) Run. The workflow will add them to the Backlog column.

This is needed because GitHub MCP currently does not provide a direct Projects v2 API wrapper. The workflow uses `actions/github-script` with GraphQL under the hood.