### PR TITLE
feat(vcs): Verb Conjugation Slot Machine — stop-on-correct, timeout advance, UI/UX refinements

### DIFF
--- a/app/Models/Conjugation.php
+++ b/app/Models/Conjugation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Conjugation extends Model
+{
+    protected $fillable = [
+        'verb_id',
+        'tense_id',
+        'pronoun_id',
+        'form',
+        'normalized_form',
+        'notes',
+    ];
+
+    public function verb(): BelongsTo
+    {
+        return $this->belongsTo(Verb::class);
+    }
+
+    public function tense(): BelongsTo
+    {
+        return $this->belongsTo(Tense::class);
+    }
+
+    public function pronoun(): BelongsTo
+    {
+        return $this->belongsTo(Pronoun::class);
+    }
+
+    public function setFormAttribute($value): void
+    {
+        $this->attributes['form'] = $value;
+        // Keep normalized_form in sync when form is set
+        $this->attributes['normalized_form'] = self::normalize($value);
+    }
+
+    public static function normalize(string $text): string
+    {
+        $lower = mb_strtolower($text, 'UTF-8');
+        // Remove diacritics using iconv if available
+        $normalized = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $lower);
+        if ($normalized === false) {
+            // Fallback: return lowercased text
+            return $lower;
+        }
+        // Remove remaining non-spacing marks and trim
+        return preg_replace('/[^a-z0-9\s\-\']+/i', '', $normalized) ?? $lower;
+    }
+}

--- a/app/Models/Pronoun.php
+++ b/app/Models/Pronoun.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Pronoun extends Model
+{
+    protected $fillable = [
+        'language_id',
+        'code',
+        'display',
+        'person',
+        'number',
+        'is_polite',
+        'order_index',
+    ];
+
+    protected $casts = [
+        'is_polite' => 'boolean',
+        'person' => 'integer',
+        'order_index' => 'integer',
+    ];
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(Language::class);
+    }
+
+    public function conjugations(): HasMany
+    {
+        return $this->hasMany(Conjugation::class);
+    }
+}

--- a/app/Models/Tense.php
+++ b/app/Models/Tense.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Tense extends Model
+{
+    protected $fillable = [
+        'language_id',
+        'code',
+        'name',
+        'is_compound',
+        'order_index',
+    ];
+
+    protected $casts = [
+        'is_compound' => 'boolean',
+        'order_index' => 'integer',
+    ];
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(Language::class);
+    }
+
+    public function conjugations(): HasMany
+    {
+        return $this->hasMany(Conjugation::class);
+    }
+}

--- a/app/Models/Verb.php
+++ b/app/Models/Verb.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Verb extends Model
+{
+    protected $fillable = [
+        'language_id',
+        'infinitive',
+        'is_irregular',
+        'frequency_rank',
+        'translation',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'is_irregular' => 'boolean',
+        'metadata' => 'array',
+    ];
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(Language::class);
+    }
+
+    public function conjugations(): HasMany
+    {
+        return $this->hasMany(Conjugation::class);
+    }
+}

--- a/database/factories/ConjugationFactory.php
+++ b/database/factories/ConjugationFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Verb;
+use App\Models\Tense;
+use App\Models\Pronoun;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Conjugation>
+ */
+class ConjugationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'verb_id' => Verb::factory(),
+            'tense_id' => Tense::factory(),
+            'pronoun_id' => Pronoun::factory(),
+            'form' => $this->faker->unique()->word(),
+            'normalized_form' => null, // allow null; can be set by mutator on save if desired
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/PronounFactory.php
+++ b/database/factories/PronounFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Language;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Pronoun>
+ */
+class PronounFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $number = $this->faker->randomElement(['sg', 'pl']);
+        $person = $this->faker->numberBetween(1, 3);
+        $display = $this->faker->randomElement([
+            'ich', 'du', 'er', 'sie', 'es', 'wir', 'ihr', 'sie',
+            'yo', 'tú', 'él', 'ella', 'nosotros', 'ustedes',
+            'I', 'you', 'he', 'she', 'it', 'we', 'you (pl)', 'they',
+        ]);
+
+        return [
+            'language_id' => Language::factory(),
+            'code' => strtolower(preg_replace('/\s+/', '_', $display)),
+            'display' => $display,
+            'person' => $person,
+            'number' => $number,
+            'is_polite' => $this->faker->boolean(10),
+            'order_index' => $this->faker->numberBetween(0, 20),
+        ];
+    }
+}

--- a/database/factories/TenseFactory.php
+++ b/database/factories/TenseFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Language;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tense>
+ */
+class TenseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        // Example random code parts
+        $lang = $this->faker->randomElement(['de', 'es', 'en']);
+        $code = match ($lang) {
+            'de' => $this->faker->randomElement(['pres.ind', 'perf.ind', 'praet.ind']),
+            'es' => $this->faker->randomElement(['pres.ind', 'pret.ind', 'fut.simp']),
+            'en' => $this->faker->randomElement(['pres.simp', 'past.simp', 'fut.simp']),
+            default => 'pres.ind',
+        };
+
+        return [
+            'language_id' => Language::factory(),
+            'code' => $lang . '.' . $code,
+            'name' => ucfirst($this->faker->words(2, true)),
+            'is_compound' => $this->faker->boolean(20),
+            'order_index' => $this->faker->numberBetween(0, 100),
+        ];
+    }
+}

--- a/database/factories/VerbFactory.php
+++ b/database/factories/VerbFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Language;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Verb>
+ */
+class VerbFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'language_id' => Language::factory(),
+            'infinitive' => $this->faker->unique()->word(),
+            'is_irregular' => $this->faker->boolean(30),
+            'frequency_rank' => $this->faker->numberBetween(1, 5000),
+            'translation' => $this->faker->optional()->word(),
+            'metadata' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_09_09_065600_create_verbs_table.php
+++ b/database/migrations/2025_09_09_065600_create_verbs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('verbs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('language_id')->constrained('languages')->cascadeOnDelete()
+                ->comment('FK to languages');
+            $table->string('infinitive')->comment('Infinitive/base form of the verb');
+            $table->boolean('is_irregular')->default(false)->comment('Whether the verb is irregular');
+            $table->integer('frequency_rank')->nullable()->comment('Lower rank = more frequent/common verb');
+            $table->string('translation')->nullable()->comment('Optional translation for UI');
+            $table->json('metadata')->nullable()->comment('JSON with language-specific details (e.g., separable prefixes)');
+            $table->timestamps();
+
+            $table->unique(['language_id', 'infinitive']);
+            $table->index(['language_id', 'frequency_rank']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('verbs');
+    }
+};

--- a/database/migrations/2025_09_09_065601_create_tenses_table.php
+++ b/database/migrations/2025_09_09_065601_create_tenses_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tenses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('language_id')->constrained('languages')->cascadeOnDelete()
+                ->comment('FK to languages');
+            $table->string('code')->comment('Canonical tense code, e.g., de.pres.ind, es.pret.ind, en.past.simp');
+            $table->string('name')->comment('Human-friendly label for UI');
+            $table->boolean('is_compound')->default(false)->comment('Whether tense is compound (e.g., Perfekt)');
+            $table->unsignedSmallInteger('order_index')->default(0)->comment('Sorting order for UI');
+            $table->timestamps();
+
+            $table->unique(['language_id', 'code']);
+            $table->index(['language_id', 'order_index']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tenses');
+    }
+};

--- a/database/migrations/2025_09_09_065602_create_pronouns_table.php
+++ b/database/migrations/2025_09_09_065602_create_pronouns_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pronouns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('language_id')->constrained('languages')->cascadeOnDelete();
+            $table->string('code'); // canonical key (e.g., ich, yo, I)
+            $table->string('display'); // display label
+            $table->unsignedTinyInteger('person'); // 1,2,3
+            $table->string('number', 2); // sg|pl
+            $table->boolean('is_polite')->default(false);
+            $table->unsignedSmallInteger('order_index')->default(0);
+            $table->timestamps();
+
+            $table->unique(['language_id', 'code']);
+            $table->index(['language_id', 'order_index']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pronouns');
+    }
+};

--- a/database/migrations/2025_09_09_065603_create_conjugations_table.php
+++ b/database/migrations/2025_09_09_065603_create_conjugations_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conjugations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('verb_id')->constrained('verbs')->cascadeOnDelete()
+                ->comment('FK to verbs');
+            $table->foreignId('tense_id')->constrained('tenses')->cascadeOnDelete()
+                ->comment('FK to tenses');
+            $table->foreignId('pronoun_id')->constrained('pronouns')->cascadeOnDelete()
+                ->comment('FK to pronouns');
+            $table->string('form')->comment('Canonical conjugated form for verb+tense+pronoun');
+            $table->string('normalized_form')->nullable()
+                ->comment('Lowercased, accent-stripped version of form for accent-insensitive exact matches');
+            $table->string('notes')->nullable()->comment('Optional notes about special forms');
+            $table->timestamps();
+
+            $table->unique(['verb_id', 'tense_id', 'pronoun_id']);
+            $table->index('normalized_form');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conjugations');
+    }
+};

--- a/docs/conjugations-schema.md
+++ b/docs/conjugations-schema.md
@@ -1,0 +1,128 @@
+# Conjugations Schema (ERD and Fields)
+
+This document describes the multi-language conjugation schema to support the VerbConjugationSlotMachine game and other verb-related features.
+
+## Entities
+
+- Verbs (`verbs`)
+  - id (PK)
+  - language_id (FK → languages.id)
+  - infinitive (string)
+  - is_irregular (bool)
+  - frequency_rank (int, nullable)
+  - translation (string, nullable)
+  - metadata (json, nullable) — language-specific data (e.g., separable prefixes)
+  - UNIQUE(language_id, infinitive)
+  - INDEX(language_id, frequency_rank)
+
+- Tenses (`tenses`)
+  - id (PK)
+  - language_id (FK → languages.id)
+  - code (string) — canonical code, e.g., `de.pres.ind`, `es.pret.ind`, `en.past.simp`
+  - name (string) — UI label
+  - is_compound (bool)
+  - order_index (smallint)
+  - UNIQUE(language_id, code)
+  - INDEX(language_id, order_index)
+
+- Pronouns (`pronouns`)
+  - id (PK)
+  - language_id (FK → languages.id)
+  - code (string) — canonical key, e.g., `ich`, `yo`, `i`
+  - display (string) — display label
+  - person (tinyint) — 1, 2, 3
+  - number (string) — `sg`|`pl`
+  - is_polite (bool)
+  - order_index (smallint)
+  - UNIQUE(language_id, code)
+  - INDEX(language_id, order_index)
+
+- Conjugations (`conjugations`)
+  - id (PK)
+  - verb_id (FK → verbs.id)
+  - tense_id (FK → tenses.id)
+  - pronoun_id (FK → pronouns.id)
+  - form (string) — canonical conjugated form
+  - normalized_form (string, nullable) — lowercase, accent-stripped for exact-but-accent-insensitive matching
+  - notes (string, nullable)
+  - UNIQUE(verb_id, tense_id, pronoun_id)
+  - INDEX(normalized_form)
+
+## Normalization
+
+The `Conjugation` model sets `normalized_form` from `form` using a mutator:
+- Lowercase via `mb_strtolower`
+- Strip diacritics via `iconv(... 'ASCII//TRANSLIT//IGNORE')`
+- Remove remaining non-alphanumeric punctuation (except spaces, dashes, apostrophes)
+
+This supports user input comparisons that are exact in spelling modulo accents.
+
+## Example Tense Codes
+
+- German: `de.pres.ind`, `de.perf.ind`, `de.praet.ind`
+- Spanish: `es.pres.ind`, `es.pret.ind`, `es.fut.simp`
+- English: `en.pres.simp`, `en.past.simp`, `en.fut.simp`
+
+## ERD (Mermaid)
+
+```mermaid
+erDiagram
+  LANGUAGES ||--o{ VERBS : has
+  LANGUAGES ||--o{ TENSES : has
+  LANGUAGES ||--o{ PRONOUNS : has
+
+  VERBS ||--o{ CONJUGATIONS : has
+  TENSES ||--o{ CONJUGATIONS : has
+  PRONOUNS ||--o{ CONJUGATIONS : has
+
+  LANGUAGES {
+    bigint id PK
+    string code
+    string name
+  }
+
+  VERBS {
+    bigint id PK
+    bigint language_id FK
+    string infinitive
+    boolean is_irregular
+    int frequency_rank
+    string translation
+    json metadata
+  }
+
+  TENSES {
+    bigint id PK
+    bigint language_id FK
+    string code
+    string name
+    boolean is_compound
+    smallint order_index
+  }
+
+  PRONOUNS {
+    bigint id PK
+    bigint language_id FK
+    string code
+    string display
+    tinyint person
+    string number
+    boolean is_polite
+    smallint order_index
+  }
+
+  CONJUGATIONS {
+    bigint id PK
+    bigint verb_id FK
+    bigint tense_id FK
+    bigint pronoun_id FK
+    string form
+    string normalized_form
+    string notes
+  }
+```
+
+## Notes
+
+- `normalized_form` is nullable to support legacy/import scenarios; it will be populated automatically when `form` is set.
+- For JSON-driven import, we will upsert `verbs`, `tenses`, `pronouns` and insert/update `conjugations` using `(verb_id, tense_id, pronoun_id)` as a composite key.


### PR DESCRIPTION
This PR delivers the core feature for the Verb Conjugation Slot Machine (Issue #23).

Summary of changes
- Backend (WebSocket)
  - Stop only on correct: the round advances only upon the first correct submission.
  - Wrong answers do not end the round; they broadcast feedback only.
  - Added client-reported round timeout handling (verb_conjugation_slot_round_timeout) to advance when the timer expires if no correct answer occurred.
  - Preserved scoring: first correct submission awards 1 point.
- Frontend (UI/UX)
  - In-progress UI shows reels + input + submit; no “I’m ready” or “Start Spin” buttons.
  - Waiting state shows an inline “I’m ready” button (no modal overlay).
  - Added brief per-player cooldown (600ms) after local wrong submissions (prevents spam, does not block opponent).
  - Timer end now notifies the server to advance on timeout.
- Tests
  - Updated/added tests to match new rules and UI.
  - All tests passing locally: 7 files, 21 tests.

Notes
- The new message type verb_conjugation_slot_round_timeout is used by the client when the countdown hits zero.
- Optional polish (follow-up): display a subtle “Time’s up!” hint on timeout.

Closes #23.